### PR TITLE
feat: サービス取得、タスク取得の関数を公開

### DIFF
--- a/lib/strategy/strategy.ex
+++ b/lib/strategy/strategy.ex
@@ -172,7 +172,7 @@ defmodule ClusterEcs.Strategy do
     end)
   end
 
-  defp list_services(cluster, region) do
+  def list_services(cluster, region) do
     params = %{
       "cluster" => cluster
     }
@@ -182,7 +182,7 @@ defmodule ClusterEcs.Strategy do
     |> list_services(cluster, region, [])
   end
 
-  defp list_services({:ok, %{"nextToken" => next_token, "serviceArns" => service_arns}}, cluster, region, accum)
+  def list_services({:ok, %{"nextToken" => next_token, "serviceArns" => service_arns}}, cluster, region, accum)
        when not is_nil(next_token) do
     params = %{
       "cluster" => cluster,
@@ -194,15 +194,15 @@ defmodule ClusterEcs.Strategy do
     |> list_services(cluster, region, accum ++ service_arns)
   end
 
-  defp list_services({:ok, %{"serviceArns" => service_arns}}, _cluster, _region, accum) do
+  def list_services({:ok, %{"serviceArns" => service_arns}}, _cluster, _region, accum) do
     {:ok, %{"serviceArns" => accum ++ service_arns}}
   end
 
-  defp list_services({:error, message}, _cluster, _region, _accum) do
+  def list_services({:error, message}, _cluster, _region, _accum) do
     {:error, message}
   end
 
-  defp list_tasks(cluster, service_arn, region) do
+  def list_tasks(cluster, service_arn, region) do
     params = %{
       "cluster" => cluster,
       "serviceName" => service_arn,
@@ -213,7 +213,7 @@ defmodule ClusterEcs.Strategy do
     |> ExAws.request(region: region)
   end
 
-  defp describe_tasks(cluster, task_arns, region) do
+  def describe_tasks(cluster, task_arns, region) do
     params = %{
       "cluster" => cluster,
       "tasks" => task_arns
@@ -238,11 +238,11 @@ defmodule ClusterEcs.Strategy do
     )
   end
 
-  defp extract_task_arns(%{"taskArns" => arns}), do: {:ok, arns}
-  defp extract_task_arns(_), do: {:error, "unknown task arns response"}
+  def extract_task_arns(%{"taskArns" => arns}), do: {:ok, arns}
+  def extract_task_arns(_), do: {:error, "unknown task arns response"}
 
-  defp extract_service_arns(%{"serviceArns" => arns}), do: {:ok, arns}
-  defp extract_service_arns(_), do: {:error, "unknown service arns response"}
+  def extract_service_arns(%{"serviceArns" => arns}), do: {:ok, arns}
+  def extract_service_arns(_), do: {:error, "unknown service arns response"}
 
   defp find_service_arn(service_arns, service_name) when is_list(service_arns) do
     with {:ok, regex} <- Regex.compile(service_name) do

--- a/mix.lock
+++ b/mix.lock
@@ -17,7 +17,7 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/cluster_ecs_test.exs
+++ b/test/cluster_ecs_test.exs
@@ -71,6 +71,23 @@ defmodule ClusterEcsTest do
     end
   end
 
+  test "gets resources from cluster", context do
+    # This test shows how to use functions to get resources (Their functions were private in original repository)
+    region = region()
+    {:ok, services} = ClusterEcs.Strategy.list_services(context.cluster, region)
+    {:ok, service_arns} = ClusterEcs.Strategy.extract_service_arns(services)
+    assert length(service_arns) > 0
+
+    for service_arn <- service_arns do
+      {:ok, tasks} = ClusterEcs.Strategy.list_tasks(context.cluster, service_arn, region)
+      {:ok, task_arns} = ClusterEcs.Strategy.extract_task_arns(tasks)
+      assert length(task_arns) > 0
+
+      desc_tasks = ClusterEcs.Strategy.describe_tasks(context.cluster, task_arns, region)
+      assert match?({:ok, _}, desc_tasks)
+    end
+  end
+
   # Since this package does not provide nor depend on full-featured ExAws.Ecs, we rely on aws-cli for testing.
   defp get_raw_string_via_aws_cli(args) do
     {output, 0} = System.cmd("aws", args)


### PR DESCRIPTION
siiibo-appで別用途にも流用したいため、サービスやタスク取得の関数を公開しました

#### やったこと

- サービス取得とタスク取得の関数を公開
- 動作確認用のテストの追加
- ssl_verify_funのバージョンアップデート
  - ローカルで動作確認する際、当ライブラリのバージョンが1.1.6だとElixirとErlangのバージョンが合わずコンパイルエラーが出てしまい、バージョンアップを試した結果通ったため。動作確認は、siiibo-appと同じバージョンをmiseでglobalに入れて実施しました。
  - 参考Issue: https://github.com/deadtrickster/ssl_verify_fun.erl/issues/29